### PR TITLE
Update run-local.sh

### DIFF
--- a/etherpad/bin/run-local.sh
+++ b/etherpad/bin/run-local.sh
@@ -96,7 +96,7 @@ exec $JAVA -classpath $CP \
     -Xms${MXRAM} \
     -XX:NewSize=768m \
     -XX:PermSize=256m \
-    -XX:MaxPermSize=2048m \
+    -XX:MaxPermSize=512m \
     -Djava.awt.headless=true \
     -Djava.util.logging.config.file=../infrastructure/lib/logging.properties \
     -XX:MaxGCPauseMillis=500 \


### PR DESCRIPTION
This is to fix installing on ubuntu #6. 

MaxPermSize is causing the below issue and lowering it to 512m solved the problem.

bin/run.sh: line 27: /home/some_user/git/hackpad/bin/ooffice.sh: no such file or directory
Maximum ram: 1656M
Maximum thread count: 276
Using config file: ./etc/etherpad.local.properties
Error occurred during initialization of VM
Could not reserve enough space for object heap
